### PR TITLE
fix: type error in MealController.createMeal

### DIFF
--- a/src/domains/meal/meal.controller.ts
+++ b/src/domains/meal/meal.controller.ts
@@ -35,7 +35,7 @@ export class MealController extends Controller {
   @SuccessResponse("201", "Created") // Custom success response
   @Post()
   public async createMeal(
-    @Body() requestBody: Omit<TMeal, "meals">
+    @Body() requestBody: TMeal
   ): Promise<TMeal> {
     this.setStatus(201); // set return status 201
     return this.service.repo.create(requestBody);

--- a/src/domains/meal/meal.controller.ts
+++ b/src/domains/meal/meal.controller.ts
@@ -35,7 +35,7 @@ export class MealController extends Controller {
   @SuccessResponse("201", "Created") // Custom success response
   @Post()
   public async createMeal(
-    @Body() requestBody: TMeal
+    @Body() requestBody: Omit<TMeal, "ingredients">
   ): Promise<TMeal> {
     this.setStatus(201); // set return status 201
     return this.service.repo.create(requestBody);


### PR DESCRIPTION
On running `pnpm generate:routes` after running `pnpm i`, I was greeted with the error:
```
There was a problem resolving type of 'Pick<TMeal, Exclude<keyof TMeal, "meals">>'.
There was a problem resolving type of 'Omit<TMeal, "meals">'.
Generate routes error.
 GenerateMetadataError: No matching model found for referenced type TIngredient. 
 in 'MealController.createMeal'
...
```
On debugging, I found that `meals` is not a field in `TMeal` so it cannot be `Omit`ted, hence this fix.