### PR TITLE
Error handling that does not suck.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       gherkin:
         specifier: npm:@cucumber/gherkin@latest
         version: /@cucumber/gherkin@26.2.0
+      http-status:
+        specifier: ^1.6.2
+        version: 1.6.2
       inversify:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3863,6 +3866,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /http-status@1.6.2:
+    resolution: {integrity: sha512-oUExvfNckrpTpDazph7kNG8sQi5au3BeTo0idaZFXEhTaJKu7GNJCLHI0rYY2wljm548MSTM+Ljj/c6anqu2zQ==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}

--- a/recipe-api/package.json
+++ b/recipe-api/package.json
@@ -32,9 +32,10 @@
   },
   "dependencies": {
     "@tsoa/runtime": "^5.0.0",
+    "cucumber-messages": "npm:@cucumber/messages@latest",
     "express": "^4.18.2",
     "gherkin": "npm:@cucumber/gherkin@latest",
-    "cucumber-messages": "npm:@cucumber/messages@latest",
+    "http-status": "^1.6.2",
     "inversify": "^6.0.1",
     "inversify-binding-decorators": "^4.0.0",
     "mongoose": "^7.2.0",

--- a/recipe-api/src/common/error/controller-errors.ts
+++ b/recipe-api/src/common/error/controller-errors.ts
@@ -1,0 +1,62 @@
+import httpStatus from "http-status";
+
+interface ControllerErrorHandler {
+  handle: (error: unknown) => ControllerError;
+}
+
+export interface ControllerError {
+  error: { name: string; message?: string };
+}
+
+export const mapControllerErrors = (
+  mapping: Record<string, number>,
+  {
+    setStatus,
+    logError,
+  }: { setStatus: (code: number) => void; logError?: (error: unknown) => void }
+): ControllerErrorHandler => {
+  logError = logError || console.error;
+  mapping = {
+    ...mapping,
+    ZodError: httpStatus.BAD_REQUEST,
+  };
+
+  return {
+    handle: (error: unknown) => {
+      logError?.(error);
+      const name =
+        error &&
+        typeof error === "object" &&
+        "name" in error &&
+        typeof error.name === "string" &&
+        error.name in mapping
+          ? error.name
+          : "InternalServerError";
+      const message =
+        error &&
+        typeof error === "object" &&
+        "message" in error &&
+        typeof error.message === "string"
+          ? error.message
+          : "Internal Server Error";
+      const isHumanReadable =
+        error &&
+        typeof error === "object" &&
+        "isHumanReadable" in error &&
+        typeof error.isHumanReadable === "boolean"
+          ? error.isHumanReadable
+          : false;
+      const code =
+        (!error ? httpStatus.INTERNAL_SERVER_ERROR : mapping[name]) ||
+        httpStatus.INTERNAL_SERVER_ERROR;
+      setStatus(code);
+
+      return {
+        error: {
+          name,
+          ...(isHumanReadable ? { message } : {}),
+        },
+      };
+    },
+  };
+};

--- a/recipe-api/src/common/error/index.ts
+++ b/recipe-api/src/common/error/index.ts
@@ -1,0 +1,3 @@
+export * from "./controller-errors";
+export * from "./service-errors";
+export * from "./make-error";

--- a/recipe-api/src/common/error/make-error.ts
+++ b/recipe-api/src/common/error/make-error.ts
@@ -1,0 +1,8 @@
+export const makeError = <TErrorName extends string>(
+  name: TErrorName,
+  message?: string
+) => ({
+  name,
+  message,
+  isHumanReadable: true,
+});

--- a/recipe-api/src/common/error/service-errors.ts
+++ b/recipe-api/src/common/error/service-errors.ts
@@ -1,0 +1,51 @@
+import { makeError } from "./make-error";
+
+export type ServiceError = { name: string; message?: string };
+
+interface ServiceErrorHandler {
+  handle: (error: unknown) => ServiceError;
+}
+
+export const mapServiceErrors = (
+  mapping: Record<string, ReturnType<typeof makeError>>,
+  { logError }: { logError?: (error: unknown) => void } = {}
+): ServiceErrorHandler => {
+  logError = logError || console.error;
+  mapping = {
+    ...mapping,
+  };
+
+  return {
+    handle: (error: unknown) => {
+      logError?.(error);
+      const name =
+        error &&
+        typeof error === "object" &&
+        "name" in error &&
+        typeof error.name === "string" &&
+        error.name in mapping
+          ? error.name
+          : "InternalServerError";
+      const message =
+        error &&
+        typeof error === "object" &&
+        "message" in error &&
+        typeof error.message === "string"
+          ? error.message
+          : "Internal Server Error";
+      const isHumanReadable =
+        error &&
+        typeof error === "object" &&
+        "isHumanReadable" in error &&
+        typeof error.isHumanReadable === "boolean"
+          ? error.isHumanReadable
+          : false;
+      return (
+        mapping[name] || {
+          name,
+          ...(isHumanReadable ? { message } : {}),
+        }
+      );
+    },
+  };
+};

--- a/recipe-api/src/domains/ingredient/ingredient.controller.ts
+++ b/recipe-api/src/domains/ingredient/ingredient.controller.ts
@@ -1,3 +1,4 @@
+import httpStatus from "http-status";
 import {
   Body,
   Controller,
@@ -6,19 +7,34 @@ import {
   Patch,
   Path,
   Post,
+  Response,
   Route,
   SuccessResponse,
 } from "tsoa";
 import { Ingredient } from "./ingredient.model";
 import { IRepository, Model, iocResolver } from "../../common";
+import { ControllerError, mapControllerErrors } from "../../common/error";
+import { Errors } from "./ingredient.service";
 
 type TIngredient = Ingredient<{ name: string }>;
 type TService = {
   repo: IRepository<Model<TIngredient>>;
+  getIngredients: () => Promise<Ingredient<{ name: string }>[]>;
 };
 
 @Route("ingredients")
 export class IngredientController extends Controller {
+  private errors = mapControllerErrors(
+    {
+      [Errors.ValidationError.name]: httpStatus.BAD_REQUEST,
+      [Errors.IngredientConflictError.name]: httpStatus.CONFLICT,
+      [Errors.IngredientDoesNotTasteGoodError.name]: httpStatus.FORBIDDEN,
+    },
+    {
+      setStatus: this.setStatus.bind(this),
+    }
+  );
+
   constructor(
     private service: TService = iocResolver.resolve("service:ingredients")?.()
   ) {
@@ -26,37 +42,64 @@ export class IngredientController extends Controller {
   }
 
   @Get()
-  public async getIngredients(): Promise<TIngredient[]> {
-    return this.service.repo.all({});
+  @Response<ControllerError>(400, "Bad Request e.g.")
+  @Response<ControllerError>(
+    403,
+    `Forbidden e.g. ${[Errors.IngredientDoesNotTasteGoodError.name].join(", ")}`
+  )
+  public async getIngredients(): Promise<TIngredient[] | ControllerError> {
+    try {
+      return await this.service.getIngredients();
+    } catch (err) {
+      return this.errors.handle(err);
+    }
   }
 
   @Get("{ingredientId}")
   public async getIngredientById(
     @Path() ingredientId: string
-  ): Promise<TIngredient> {
-    return this.service.repo.byQuery({ _id: ingredientId });
+  ): Promise<TIngredient | ControllerError> {
+    try {
+      return await this.service.repo.byQuery({ _id: ingredientId });
+    } catch (err) {
+      return this.errors.handle(err);
+    }
   }
 
   @SuccessResponse("201", "Created") // Custom success response
   @Post()
   public async createIngredient(
     @Body() requestBody: Omit<TIngredient, "nutrients">
-  ): Promise<TIngredient> {
-    this.setStatus(201); // set return status 201
-    return this.service.repo.create(requestBody);
+  ): Promise<TIngredient | ControllerError> {
+    try {
+      this.setStatus(201); // set return status 201
+      return await this.service.repo.create(requestBody);
+    } catch (err) {
+      return this.errors.handle(err);
+    }
   }
 
   @Patch("{ingredientId}")
   public async updateIngredient(
     @Path() ingredientId: string,
     @Body() requestBody: Partial<Omit<TIngredient, "nutrients">>
-  ): Promise<TIngredient> {
-    return this.service.repo.update({ _id: ingredientId }, requestBody);
+  ): Promise<TIngredient | ControllerError> {
+    try {
+      return await this.service.repo.update({ _id: ingredientId }, requestBody);
+    } catch (err) {
+      return this.errors.handle(err);
+    }
   }
 
   @SuccessResponse("204", "No Content")
   @Delete("{ingredientId}")
-  public async deleteIngredient(@Path() ingredientId: string): Promise<void> {
-    await this.service.repo.delete({ _id: ingredientId });
+  public async deleteIngredient(
+    @Path() ingredientId: string
+  ): Promise<void | ControllerError> {
+    try {
+      await this.service.repo.delete({ _id: ingredientId });
+    } catch (err) {
+      return this.errors.handle(err);
+    }
   }
 }

--- a/recipe-api/src/tsoa/routes.ts
+++ b/recipe-api/src/tsoa/routes.ts
@@ -25,6 +25,14 @@ const models: TsoaRoute.Models = {
         "type": {"ref":"Ingredient__name-string__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ControllerError": {
+        "dataType": "refObject",
+        "properties": {
+            "error": {"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string"},"name":{"dataType":"string","required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Pick_TIngredient.Exclude_keyofTIngredient.nutrients__": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"calories":{"dataType":"double","required":true}},"validators":{}},


### PR DESCRIPTION
This PR introduces error handling that adheres to the following rules:

- Errors in the controller are handled via a mapping of error names to http status codes. All unmapped errors default to an InternalServerError.
- Errors in the service are handled via a mapping of error names to higher-level, human-readable errors.
- When working with async methods that throw errors, we want to use await to ensure that try-catch works.